### PR TITLE
Mapper creation for the product entity

### DIFF
--- a/src/main/java/com/riwi/localstorage/riwi_local_storage/api/dto/response/ProductResponse.java
+++ b/src/main/java/com/riwi/localstorage/riwi_local_storage/api/dto/response/ProductResponse.java
@@ -1,12 +1,12 @@
 package com.riwi.localstorage.riwi_local_storage.api.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
-@Builder
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProductResponse {

--- a/src/main/java/com/riwi/localstorage/riwi_local_storage/api/dto/response/ProductResponseForAdmin.java
+++ b/src/main/java/com/riwi/localstorage/riwi_local_storage/api/dto/response/ProductResponseForAdmin.java
@@ -1,25 +1,15 @@
 package com.riwi.localstorage.riwi_local_storage.api.dto.response;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
-@Builder
+@Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ProductResponseForAdmin {
-
-    private String id;
-
-    private String name;
-
-    private String description;
-
-    private String barcode;
-
-    private Double sellingPrice;
+public class ProductResponseForAdmin extends ProductResponse{
 
     private Double buyingPrice;
     

--- a/src/main/java/com/riwi/localstorage/riwi_local_storage/api/dto/response/ProductResponseForAdmin.java
+++ b/src/main/java/com/riwi/localstorage/riwi_local_storage/api/dto/response/ProductResponseForAdmin.java
@@ -11,6 +11,8 @@ import lombok.Setter;
 @NoArgsConstructor
 public class ProductResponseForAdmin extends ProductResponse{
 
+    private String id;
+
     private Double buyingPrice;
     
     private String categoryName;

--- a/src/main/java/com/riwi/localstorage/riwi_local_storage/infrastructure/mappers/ProductMapper.java
+++ b/src/main/java/com/riwi/localstorage/riwi_local_storage/infrastructure/mappers/ProductMapper.java
@@ -1,0 +1,26 @@
+package com.riwi.localstorage.riwi_local_storage.infrastructure.mappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import com.riwi.localstorage.riwi_local_storage.api.dto.request.create.ProductRequest;
+import com.riwi.localstorage.riwi_local_storage.api.dto.response.ProductResponse;
+import com.riwi.localstorage.riwi_local_storage.api.dto.response.ProductResponseForAdmin;
+import com.riwi.localstorage.riwi_local_storage.domain.entities.Product;
+
+@Mapper(componentModel = "spring")
+public interface ProductMapper {
+    
+    @Mapping(target = "id", ignore = true)
+    Product productRequestToProduct(ProductRequest request);
+
+    ProductResponse productToProductResponse(Product product);
+
+    @Mapping(target = "id", ignore = true)
+    //@Mapping(target = "id", source = "categoryId.name")
+    ProductResponseForAdmin productToProductResponseForAdmin(Product product);
+
+    @Mapping(target = "id", ignore = true)
+    void productToUpdate(ProductRequest request, @MappingTarget Product product);
+}


### PR DESCRIPTION
Implemented the `ProductMapper` interface with the `@Mapper` . For mappings between `ProductRequest`, `Product`, and corresponding response objects.

These changes facilitate seamless conversion between request and response DTOs and the domain model (`Product`). The `ProductMapper` interface aims to enhance clarity and maintainability by centralizing mapping logic, adhering to Spring's component-based architecture.

1. **productRequestToProduct**: Added method to map `ProductRequest` to `Product`.

2. **productToProductResponse**: Implemented method to convert `Product` to `ProductResponse`.

3. **productToProductResponseForAdmin**: Added method to transform `Product` to `ProductResponseForAdmin`. 

4. **productToUpdate**: Implemented method for updating an existing `Product` object using data from `ProductRequest`.


