### PR TITLE
Mapper creation for the branch entity

### DIFF
--- a/src/main/java/com/riwi/localstorage/riwi_local_storage/infrastructure/mappers/BranchMapper.java
+++ b/src/main/java/com/riwi/localstorage/riwi_local_storage/infrastructure/mappers/BranchMapper.java
@@ -1,0 +1,22 @@
+package com.riwi.localstorage.riwi_local_storage.infrastructure.mappers;
+
+import com.riwi.localstorage.riwi_local_storage.api.dto.request.create.BranchRequest;
+import com.riwi.localstorage.riwi_local_storage.api.dto.response.BranchResponse;
+import com.riwi.localstorage.riwi_local_storage.domain.entities.Branch;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+@Mapper(componentModel = "spring")
+public interface BranchMapper {
+
+    @Mapping(target = "id", ignore = true)
+    Branch branchRequestToBranch(BranchRequest request);
+
+    BranchResponse branchToBranchResponse(Branch branch);
+
+    @Mapping(target = "id", ignore = true)
+    void branchToUpdate(BranchRequest request, @MappingTarget Branch branch);
+
+
+}


### PR DESCRIPTION
I implemented the **BranchMapper** interface using the **@Mapper** annotation to handle mappings between BranchRequest, Branch, and their corresponding response objects.

These changes enable seamless conversion between request and response DTOs and the domain model (Branch). The BranchMapper interface improves clarity and maintainability by centralizing the mapping logic, adhering to Spring's component-based architecture.

- **branchRequestToBranch:** Added a method to map BranchRequest to Branch.
- **branchToBranchResponse:** Implemented a method to convert Branch to BranchResponse.
- **branchToUpdate:** Implemented a method to update an existing Branch object using data from BranchRequest.